### PR TITLE
fix: Fix The operator "<=>" is not permitted in MySQL

### DIFF
--- a/lib/formatter/wrappingFormatter.js
+++ b/lib/formatter/wrappingFormatter.js
@@ -12,6 +12,7 @@ const operators = transform(
     '<',
     '>',
     '<=',
+    '<=>',
     '>=',
     '<>',
     '!=',


### PR DESCRIPTION
When trying to join using the null-safe operator, I'm getting `TypeError: The operator "<=>" is not permitted` despite being a valid value in MySQL 

See https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#operator_equal-to